### PR TITLE
Fix crash in FPicker on Android OS >= 7.0

### DIFF
--- a/src/in/celest/xash3d/FPicker.java
+++ b/src/in/celest/xash3d/FPicker.java
@@ -78,15 +78,16 @@ public class FPicker extends Activity {
 		{
 			File[] dirs = folder.listFiles();
 			List<Item> dir = new ArrayList<Item>();
-			
+
 			while( dirs == null )
 			{
-				folder = new File(folder.getParent());
-				if( folder == null )
-					return dir;
+				try {
+					folder = new File(folder.getParent());
+				} catch (NullPointerException e) {
+					folder = new File(Environment.getExternalStorageDirectory().toString());
+				}
 				dirs = folder.listFiles();
 			}
-		
 
 			for(File ff: dirs)
 			{


### PR DESCRIPTION
When I try to enter to the root directory "/" I get app crash on Android OS >= 7.0

![to_gh_a](https://user-images.githubusercontent.com/232116/27465264-8f85edb0-57fc-11e7-8cc5-75335676c4c6.jpg)

```
D/OpenGLRenderer: endAllActiveAnimators on 0x9d90fb00 (RippleDrawable) with handle 0xab3c95f0
E/AndroidRuntime: FATAL EXCEPTION: AsyncTask #5
	Process: in.celest.xash3d.hl, PID: 2453
	java.lang.RuntimeException: An error occurred while executing doInBackground()
		at android.os.AsyncTask$3.done(AsyncTask.java:325)
		at java.util.concurrent.FutureTask.finishCompletion(FutureTask.java:354)
		at java.util.concurrent.FutureTask.setException(FutureTask.java:223)
		at java.util.concurrent.FutureTask.run(FutureTask.java:242)
		at android.os.AsyncTask$SerialExecutor$1.run(AsyncTask.java:243)
		at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1133)
		at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:607)
		at java.lang.Thread.run(Thread.java:761)
	Caused by: java.lang.NullPointerException
		at java.io.File.<init>(File.java:262)
		at in.celest.xash3d.FPicker$Fill.doInBackground(FPicker.java:84)
		at in.celest.xash3d.FPicker$Fill.doInBackground(FPicker.java:68)
		at android.os.AsyncTask$2.call(AsyncTask.java:305)
		at java.util.concurrent.FutureTask.run(FutureTask.java:237)
		at android.os.AsyncTask$SerialExecutor$1.run(AsyncTask.java:243)
		at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1133)
		at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:607)
		at java.lang.Thread.run(Thread.java:761)
D/OpenGLRenderer: endAllActiveAnimators on 0x9ccb3200 (ListView) with handle 0x9c5f3390
```
When directory list **dirs** is null and **folder** variable is root "/" the `folder = new File(folder.getParent())` expression throws the `NullPointerException` exception.

In addition, the code which was supposed to return **dir** list never worked:

![screenshot_20170623_094628](https://user-images.githubusercontent.com/232116/27465591-b1dee6bc-57fe-11e7-8bbf-9a762bca5dcc.png)
